### PR TITLE
Add basic Node.js SDK for MimePost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # mimepost-js
+
+A tiny and beginner-friendly Node.js SDK for the [MimePost](https://mimepost.com) API.
+
+## Installation
+
+```bash
+npm install mimepost-js
+```
+
+## Usage
+
+```javascript
+const MimePostClient = require('mimepost-js');
+
+const client = new MimePostClient({ apiToken: 'YOUR_API_TOKEN' });
+
+// Send a transactional email
+await client.sendEmail({
+  template_uid: 'welcome_email',
+  subject: 'Welcome!',
+  from_email: 'from@example.com',
+  to: [{ email: 'to@example.com' }]
+});
+
+// List templates
+const templates = await client.listTemplates();
+
+// Get a single template
+const template = await client.getTemplate('welcome_email');
+```
+
+The SDK was created from the Postman collection in `postman.json`. Refer to that file or the official MimePost documentation for all available endpoints and parameters.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mimepost-js",
+  "version": "0.1.0",
+  "description": "Simple Node.js SDK for the MimePost API",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": ["mimepost", "email", "sdk"],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,37 @@
+class MimePostClient {
+  constructor({ apiToken, baseUrl = 'https://api.mimepost.com/v1/' } = {}) {
+    if (!apiToken) throw new Error('apiToken is required');
+    this.apiToken = apiToken;
+    this.baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+  }
+
+  async sendEmail(payload) {
+    return this.#request('emails/', { method: 'POST', body: payload });
+  }
+
+  async listTemplates() {
+    return this.#request('templates/', { method: 'GET' });
+  }
+
+  async getTemplate(templateUid) {
+    if (!templateUid) throw new Error('templateUid is required');
+    return this.#request(`templates/${templateUid}`, { method: 'GET' });
+  }
+
+  async #request(path, { method = 'GET', body } = {}) {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Auth-Token': this.apiToken,
+    };
+    const options = { method, headers };
+    if (body) options.body = JSON.stringify(body);
+    const res = await fetch(this.baseUrl + path, options);
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Request failed with status ${res.status}: ${text}`);
+    }
+    return res.json();
+  }
+}
+
+module.exports = MimePostClient;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const MimePostClient = require('../src');
+
+test('calls fetch with proper url and headers', async () => {
+  const calls = [];
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ success: true }) };
+  };
+  const client = new MimePostClient({ apiToken: 'test-token' });
+  await client.getTemplate('welcome');
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0].url, 'https://api.mimepost.com/v1/templates/welcome');
+  assert.strictEqual(calls[0].options.headers['X-Auth-Token'], 'test-token');
+});


### PR DESCRIPTION
## Summary
- add beginner-friendly MimePostClient with helpers to send emails and manage templates
- document installation and usage in README
- include simple tests exercising request construction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4b40c00832695ebbc2fb754db0f